### PR TITLE
fix: Prevent entity loss on HA restart by handling connection failure…

### DIFF
--- a/custom_components/gecko/__init__.py
+++ b/custom_components/gecko/__init__.py
@@ -9,6 +9,7 @@ import os
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client, config_entry_oauth2_flow, config_validation as cv, device_registry as dr
 
 
@@ -91,7 +92,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     # Create devices for each vessel/spa and set up geckoIotClient
-    await _setup_vessels_and_gecko_clients(hass, entry)
+    # If connection fails, raise ConfigEntryNotReady so HA retries automatically
+    try:
+        await _setup_vessels_and_gecko_clients(hass, entry)
+    except Exception as ex:
+        raise ConfigEntryNotReady(f"Failed to connect to Gecko device: {ex}") from ex
 
     # Set up platforms immediately - entities will be created when zone data becomes available
     await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
@@ -122,6 +127,8 @@ async def _setup_vessels_and_gecko_clients(hass: HomeAssistant, entry: ConfigEnt
             await _setup_vessel_gecko_client(vessel, api_client, coordinator)
         except Exception as e:
             _LOGGER.error("Failed to setup vessel %s: %s", vessel_name, e, exc_info=True)
+            # Re-raise to allow async_setup_entry to handle with ConfigEntryNotReady
+            raise
 
 
 def _setup_vessel_device(entry: ConfigEntry, vessel: dict, device_registry: dr.DeviceRegistry) -> None:

--- a/custom_components/gecko/connection_manager.py
+++ b/custom_components/gecko/connection_manager.py
@@ -24,6 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 # Constants
 TOKEN_REFRESH_DELAY = 1  # seconds to wait before getting new token
 RECONNECT_DELAY = 2  # seconds to wait before reconnecting
+TOKEN_REFRESH_TIMEOUT = 30  # seconds to wait for token refresh before timing out
 
 # Global key for the connection manager
 GECKO_CONNECTION_MANAGER_KEY: HassKey[GeckoConnectionManager] = HassKey(
@@ -42,6 +43,7 @@ class GeckoMonitorConnection:
     update_callbacks: list[Callable[[dict], None]] = field(default_factory=list)
     is_connected: bool = False
     connectivity_status: Any = None  # ConnectivityStatus from geckoIotClient
+    refresh_token_callback: Callable[[str | None], str] | None = None  # Store callback for reconnection
     
 
 class GeckoConnectionManager:
@@ -58,6 +60,42 @@ class GeckoConnectionManager:
         self._cleanup_listener = hass.bus.async_listen_once(
             EVENT_HOMEASSISTANT_STOP, self._async_shutdown
         )
+    
+    def _setup_client_handlers(
+        self,
+        gecko_client: Any,
+        connection: GeckoMonitorConnection,
+        monitor_id: str,
+    ) -> None:
+        """Set up zone update and connectivity handlers for a gecko client.
+        
+        This helper method extracts the common handler setup logic used when
+        creating or reconnecting monitor connections, following the DRY principle.
+        """
+        # Set up zone update handler to distribute to all callbacks
+        def on_zone_update(updated_zones):
+            # Copy callbacks list to avoid race conditions during iteration
+            callbacks = list(connection.update_callbacks)
+            for callback in callbacks:
+                try:
+                    callback(updated_zones)
+                except Exception as e:
+                    _LOGGER.error("Error in zone update callback for monitor %s: %s", monitor_id, e)
+        
+        # Set up connectivity update handler
+        def on_connectivity_update(connectivity_status):
+            # Store connectivity status in connection for easy access
+            connection.connectivity_status = connectivity_status
+            
+            # Update connection status based on connectivity
+            if hasattr(connectivity_status, 'vessel_status'):
+                # If vessel is running but transporter is not connected, we may need to refresh token
+                vessel_running = str(connectivity_status.vessel_status) == 'RUNNING'
+                if vessel_running and not connection.is_connected:
+                    _LOGGER.warning("Vessel running but connection not established for %s", monitor_id)
+        
+        gecko_client.on_zone_update(on_zone_update)
+        gecko_client.on(EventChannel.CONNECTIVITY_UPDATE, on_connectivity_update)
     
     async def async_get_or_create_connection(
         self,
@@ -91,40 +129,21 @@ class GeckoConnectionManager:
                                               transporter, 
                                               config_timeout=CONFIG_TIMEOUT)
                 
-                # Create connection object
+                # Create connection object with refresh callback for reconnection
                 connection = GeckoMonitorConnection(
                     monitor_id=monitor_id,
                     gecko_client=gecko_client,
                     websocket_url=websocket_url,
                     vessel_name=vessel_name,
+                    refresh_token_callback=refresh_token_callback,
                 )
                 
                 # Add callback if provided
                 if update_callback:
                     connection.update_callbacks.append(update_callback)
                 
-                # Set up zone update handler to distribute to all callbacks
-                def on_zone_update(updated_zones):
-                    for callback in connection.update_callbacks:
-                        try:
-                            callback(updated_zones)
-                        except Exception as e:
-                            _LOGGER.error("Error in zone update callback for monitor %s: %s", monitor_id, e)
-                
-                # Set up connectivity update handler
-                def on_connectivity_update(connectivity_status):
-                    # Store connectivity status in connection for easy access
-                    connection.connectivity_status = connectivity_status
-                    
-                    # Update connection status based on connectivity
-                    if hasattr(connectivity_status, 'vessel_status'):
-                        # If vessel is running but transporter is not connected, we may need to refresh token
-                        vessel_running = str(connectivity_status.vessel_status) == 'RUNNING'
-                        if vessel_running and not connection.is_connected:
-                            _LOGGER.warning("Vessel running but connection not established for %s", monitor_id)
-                
-                gecko_client.on_zone_update(on_zone_update)
-                gecko_client.on(EventChannel.CONNECTIVITY_UPDATE, on_connectivity_update)
+                # Set up handlers using the helper method
+                self._setup_client_handlers(gecko_client, connection, monitor_id)
                 
                 # Connect using executor since connect() is synchronous
                 await self.hass.async_add_executor_job(gecko_client.connect)
@@ -144,15 +163,19 @@ class GeckoConnectionManager:
         """Get existing connection for a monitor."""
         return self._connections.get(monitor_id)
     
-    def remove_callback(self, monitor_id: str, callback: Callable[[dict], None]) -> None:
-        """Remove a callback from a monitor connection."""
-        if monitor_id in self._connections:
-            connection = self._connections[monitor_id]
-            if callback in connection.update_callbacks:
-                connection.update_callbacks.remove(callback)
-                
-                # If no more callbacks, we could optionally disconnect
-                # For now, keep connections alive as they may be reused
+    async def async_remove_callback(self, monitor_id: str, callback: Callable[[dict], None]) -> None:
+        """Remove a callback from a monitor connection.
+        
+        Uses the connection lock to prevent race conditions with callback iteration.
+        """
+        async with self._connection_lock:
+            if monitor_id in self._connections:
+                connection = self._connections[monitor_id]
+                if callback in connection.update_callbacks:
+                    connection.update_callbacks.remove(callback)
+                    
+                    # If no more callbacks, we could optionally disconnect
+                    # For now, keep connections alive as they may be reused
     
     async def async_disconnect_monitor(self, monitor_id: str) -> None:
         """Disconnect and remove a monitor connection."""
@@ -176,34 +199,43 @@ class GeckoConnectionManager:
         This method disconnects the existing connection (if any) and establishes
         a new connection using a fresh token from the refresh callback.
         
+        The connection lock is acquired at entry to prevent race conditions
+        where the connection could be modified or removed by concurrent operations.
+        
         Returns True if reconnection was successful, False otherwise.
         """
-        if monitor_id not in self._connections:
-            _LOGGER.warning("No existing connection found for monitor %s to reconnect", monitor_id)
-            return False
-        
-        connection = self._connections[monitor_id]
-        
-        try:
-            # Get the token refresh callback from the existing connection
-            refresh_callback = None
-            if hasattr(connection.gecko_client, 'transporter') and hasattr(connection.gecko_client.transporter, '_token_refresh_callback'):
-                refresh_callback = connection.gecko_client.transporter._token_refresh_callback
-            
-            if not refresh_callback or not callable(refresh_callback):
-                _LOGGER.error("No token refresh callback available for monitor %s - cannot reconnect", monitor_id)
+        # Acquire lock at method entry to prevent race conditions
+        async with self._connection_lock:
+            if monitor_id not in self._connections:
+                _LOGGER.warning("No existing connection found for monitor %s to reconnect", monitor_id)
                 return False
             
-            # Get fresh websocket URL with new token
-            _LOGGER.debug("Getting fresh token for monitor %s", monitor_id)
-            new_url = await self.hass.async_add_executor_job(refresh_callback, monitor_id)
+            connection = self._connections[monitor_id]
             
-            if not new_url or not isinstance(new_url, str):
-                _LOGGER.error("Failed to get new websocket URL for monitor %s", monitor_id)
-                return False
-            
-            # Disconnect existing connection
-            async with self._connection_lock:
+            try:
+                # Use the stored refresh callback from connection object (avoids accessing private attributes)
+                refresh_callback = connection.refresh_token_callback
+                
+                if not refresh_callback or not callable(refresh_callback):
+                    _LOGGER.error("No token refresh callback available for monitor %s - cannot reconnect", monitor_id)
+                    return False
+                
+                # Get fresh websocket URL with new token (with timeout to prevent indefinite blocking)
+                _LOGGER.debug("Getting fresh token for monitor %s", monitor_id)
+                try:
+                    new_url = await asyncio.wait_for(
+                        self.hass.async_add_executor_job(refresh_callback, monitor_id),
+                        timeout=TOKEN_REFRESH_TIMEOUT
+                    )
+                except asyncio.TimeoutError:
+                    _LOGGER.error("Token refresh timed out after %ds for monitor %s", TOKEN_REFRESH_TIMEOUT, monitor_id)
+                    return False
+                
+                if not new_url or not isinstance(new_url, str):
+                    _LOGGER.error("Failed to get new websocket URL for monitor %s", monitor_id)
+                    return False
+                
+                # Disconnect existing connection
                 if connection.is_connected and connection.gecko_client:
                     try:
                         await self.hass.async_add_executor_job(connection.gecko_client.disconnect)
@@ -223,24 +255,8 @@ class GeckoConnectionManager:
                 
                 gecko_client = GeckoIotClient(monitor_id, transporter, config_timeout=CONFIG_TIMEOUT)
                 
-                # Set up zone update handler to distribute to all callbacks
-                def on_zone_update(updated_zones):
-                    for callback in connection.update_callbacks:
-                        try:
-                            callback(updated_zones)
-                        except Exception as e:
-                            _LOGGER.error("Error in zone update callback for monitor %s: %s", monitor_id, e)
-                
-                # Set up connectivity update handler
-                def on_connectivity_update(connectivity_status):
-                    connection.connectivity_status = connectivity_status
-                    if hasattr(connectivity_status, 'vessel_status'):
-                        vessel_running = str(connectivity_status.vessel_status) == 'RUNNING'
-                        if vessel_running and not connection.is_connected:
-                            _LOGGER.warning("Vessel running but connection not established for %s", monitor_id)
-                
-                gecko_client.on_zone_update(on_zone_update)
-                gecko_client.on(EventChannel.CONNECTIVITY_UPDATE, on_connectivity_update)
+                # Set up handlers using the helper method (DRY principle)
+                self._setup_client_handlers(gecko_client, connection, monitor_id)
                 
                 # Update connection object with new client and URL
                 connection.gecko_client = gecko_client
@@ -253,10 +269,11 @@ class GeckoConnectionManager:
                 _LOGGER.info("Successfully reconnected monitor %s", monitor_id)
                 return True
                 
-        except Exception as e:
-            _LOGGER.error("Failed to reconnect monitor %s: %s", monitor_id, e, exc_info=True)
-            connection.is_connected = False
-            return False
+            except Exception as e:
+                _LOGGER.error("Failed to reconnect monitor %s: %s", monitor_id, e, exc_info=True)
+                # State is already set to False within the lock if disconnect succeeded
+                # No need to set it again outside the lock (fixes race condition)
+                return False
     
     async def _async_shutdown(self, event: Event) -> None:
         """Shutdown all connections."""
@@ -273,39 +290,53 @@ class GeckoConnectionManager:
                 _LOGGER.error("Error in shutdown callback: %s", e)
     
     async def async_refresh_connection_token(self, monitor_id: str) -> bool:
-        """Refresh the token for a specific connection."""
-        if monitor_id not in self._connections:
-            _LOGGER.error("No connection found for monitor %s to refresh", monitor_id)
-            return False
+        """Refresh the token for a specific connection.
         
-        connection = self._connections[monitor_id]
-        
-        try:
-            # Disconnect current connection
-            if connection.gecko_client and connection.is_connected:
-                await self.hass.async_add_executor_job(connection.gecko_client.disconnect)
-                connection.is_connected = False
-            
-            # Wait briefly before getting new token
-            await asyncio.sleep(TOKEN_REFRESH_DELAY)
-
-            # Get fresh token via the refresh callback if available
-            new_url = None
-            refresh_callback = None
-            if hasattr(connection.gecko_client, 'transporter') and hasattr(connection.gecko_client.transporter, '_token_refresh_callback'):
-                refresh_callback = connection.gecko_client.transporter._token_refresh_callback
-            
-            if refresh_callback and callable(refresh_callback):
-                # Run the callback in executor since it might be blocking
-                new_url = await self.hass.async_add_executor_job(refresh_callback, monitor_id)
-                if new_url and isinstance(new_url, str) and new_url != connection.websocket_url:
-                    connection.websocket_url = new_url
-            else:
-                _LOGGER.warning("No token refresh callback available for monitor %s", monitor_id)
+        This method acquires the connection lock at entry to prevent race conditions
+        where the connection could be modified or removed by concurrent operations.
+        """
+        # Acquire lock at method entry to prevent race conditions
+        async with self._connection_lock:
+            if monitor_id not in self._connections:
+                _LOGGER.error("No connection found for monitor %s to refresh", monitor_id)
                 return False
+            
+            connection = self._connections[monitor_id]
+            
+            try:
+                # Disconnect current connection
+                if connection.gecko_client and connection.is_connected:
+                    await self.hass.async_add_executor_job(connection.gecko_client.disconnect)
+                    connection.is_connected = False
+                
+                # Wait briefly before getting new token
+                await asyncio.sleep(TOKEN_REFRESH_DELAY)
 
-            # Re-instantiate transporter and gecko client with new token
-            if new_url:
+                # Use the stored refresh callback from connection object (avoids accessing private attributes)
+                refresh_callback = connection.refresh_token_callback
+                
+                if not refresh_callback or not callable(refresh_callback):
+                    _LOGGER.warning("No token refresh callback available for monitor %s", monitor_id)
+                    return False
+
+                # Run the callback in executor with timeout to prevent indefinite blocking
+                try:
+                    new_url = await asyncio.wait_for(
+                        self.hass.async_add_executor_job(refresh_callback, monitor_id),
+                        timeout=TOKEN_REFRESH_TIMEOUT
+                    )
+                except asyncio.TimeoutError:
+                    _LOGGER.error("Token refresh timed out after %ds for monitor %s", TOKEN_REFRESH_TIMEOUT, monitor_id)
+                    return False
+                
+                if not new_url or not isinstance(new_url, str):
+                    _LOGGER.error("Failed to get new websocket URL for monitor %s", monitor_id)
+                    return False
+                
+                if new_url != connection.websocket_url:
+                    connection.websocket_url = new_url
+
+                # Re-instantiate transporter and gecko client with new token
                 transporter = MqttTransporter(
                     broker_url=new_url,
                     monitor_id=monitor_id,
@@ -315,42 +346,27 @@ class GeckoConnectionManager:
                 # Create new gecko client
                 gecko_client = GeckoIotClient(monitor_id, transporter, config_timeout=CONFIG_TIMEOUT)
                 
-                # Setup zone update handler to distribute to all callbacks
-                def on_zone_update(updated_zones):
-                    for callback in connection.update_callbacks:
-                        try:
-                            callback(updated_zones)
-                        except Exception as e:
-                            _LOGGER.error("Error in zone update callback for monitor %s: %s", monitor_id, e)
-                
-                # Set up connectivity update handler
-                def on_connectivity_update(connectivity_status):
-                    connection.connectivity_status = connectivity_status
-                    
-                    vessel_running = str(connectivity_status.vessel_status) == 'RUNNING'
-                    if vessel_running and not connection.is_connected:
-                        _LOGGER.warning("Vessel running but connection not established for %s", monitor_id)
-                
-                gecko_client.on_zone_update(on_zone_update)
-                gecko_client.on(EventChannel.CONNECTIVITY_UPDATE, on_connectivity_update)
+                # Set up handlers using the helper method (DRY principle)
+                self._setup_client_handlers(gecko_client, connection, monitor_id)
                 
                 # Update connection with new client
                 connection.gecko_client = gecko_client
 
-            # Wait briefly before reconnecting
-            await asyncio.sleep(RECONNECT_DELAY)
+                # Wait briefly before reconnecting
+                await asyncio.sleep(RECONNECT_DELAY)
 
-            # Reconnect with fresh token
-            await self.hass.async_add_executor_job(connection.gecko_client.connect)
-            connection.is_connected = True
+                # Reconnect with fresh token
+                await self.hass.async_add_executor_job(connection.gecko_client.connect)
+                connection.is_connected = True
 
-            _LOGGER.info("Refreshed and reconnected monitor %s", monitor_id)
-            return True
+                _LOGGER.info("Refreshed and reconnected monitor %s", monitor_id)
+                return True
 
-        except Exception as e:
-            _LOGGER.error("Failed to refresh token for monitor %s: %s", monitor_id, e, exc_info=True)
-            connection.is_connected = False
-            return False
+            except Exception as e:
+                _LOGGER.error("Failed to refresh token for monitor %s: %s", monitor_id, e, exc_info=True)
+                # State is already set to False within the lock if disconnect succeeded
+                # No need to set it again outside the lock (fixes race condition)
+                return False
     
     def add_shutdown_callback(self, callback: Callable[[], None]) -> None:
         """Add a callback to be called during shutdown."""

--- a/custom_components/gecko/oauth_implementation.py
+++ b/custom_components/gecko/oauth_implementation.py
@@ -19,7 +19,9 @@ class GeckoPKCEOAuth2Implementation(config_entry_oauth2_flow.LocalOAuth2Implemen
         """Extra data for the authorize URL."""
         data = super().extra_authorize_data  # This includes code_challenge and code_challenge_method
         data.update({
-            "scope": "openid profile email",
+            # offline_access is REQUIRED to receive a refresh_token from Auth0
+            # Without it, only an access_token is returned which expires and cannot be renewed
+            "scope": "openid profile email offline_access",
             "audience": "https://api.geckowatermonitor.com"
         })
         return data


### PR DESCRIPTION
Previously, when Home Assistant restarted and the initial connection to the Gecko device timed out (e.g., device temporarily offline), the integration would log the error but report setup as successful. This caused two problems:

1. Entities were never created because they depend on zone data arriving via callbacks, which never happens without a successful connection.

2. The coordinator's reconnect logic called `async_reconnect_monitor()` which didn't exist, causing repeated AttributeError failures that prevented any recovery.

This commit fixes the issue by:

- Raising `ConfigEntryNotReady` when initial connection setup fails, allowing Home Assistant to automatically retry with exponential backoff until the device becomes available.

- Adding the missing `async_reconnect_monitor()` method to GeckoConnectionManager that properly handles runtime reconnection by fetching fresh tokens and re-establishing the MQTT connection.

- Ensuring connection errors propagate correctly from `_setup_vessel_gecko_client` through to `async_setup_entry` instead of being silently caught and logged.

Fixes #11