### PR TITLE
fix: Add offline_access scope to OAuth to obtain refresh tokens

### DIFF
--- a/custom_components/gecko/__init__.py
+++ b/custom_components/gecko/__init__.py
@@ -9,6 +9,7 @@ import os
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client, config_entry_oauth2_flow, config_validation as cv, device_registry as dr
 
 
@@ -91,7 +92,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     # Create devices for each vessel/spa and set up geckoIotClient
-    await _setup_vessels_and_gecko_clients(hass, entry)
+    # If connection fails, raise ConfigEntryNotReady so HA retries automatically
+    try:
+        await _setup_vessels_and_gecko_clients(hass, entry)
+    except Exception as ex:
+        raise ConfigEntryNotReady(f"Failed to connect to Gecko device: {ex}") from ex
 
     # Set up platforms immediately - entities will be created when zone data becomes available
     await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
@@ -122,6 +127,8 @@ async def _setup_vessels_and_gecko_clients(hass: HomeAssistant, entry: ConfigEnt
             await _setup_vessel_gecko_client(vessel, api_client, coordinator)
         except Exception as e:
             _LOGGER.error("Failed to setup vessel %s: %s", vessel_name, e, exc_info=True)
+            # Re-raise to allow async_setup_entry to handle with ConfigEntryNotReady
+            raise
 
 
 def _setup_vessel_device(entry: ConfigEntry, vessel: dict, device_registry: dr.DeviceRegistry) -> None:

--- a/custom_components/gecko/oauth_implementation.py
+++ b/custom_components/gecko/oauth_implementation.py
@@ -19,7 +19,9 @@ class GeckoPKCEOAuth2Implementation(config_entry_oauth2_flow.LocalOAuth2Implemen
         """Extra data for the authorize URL."""
         data = super().extra_authorize_data  # This includes code_challenge and code_challenge_method
         data.update({
-            "scope": "openid profile email",
+            # offline_access is REQUIRED to receive a refresh_token from Auth0
+            # Without it, only an access_token is returned which expires and cannot be renewed
+            "scope": "openid profile email offline_access",
             "audience": "https://api.geckowatermonitor.com"
         })
         return data


### PR DESCRIPTION
## Summary

Fixes #24

This PR adds the `offline_access` scope to the OAuth2 authorization request, which is required by Auth0 to return a refresh token.

## Problem

Without the `offline_access` scope, Auth0 only returns an `access_token` which expires after approximately 24 hours. When the token expires, Home Assistant cannot refresh it because no `refresh_token` was provided, resulting in the error:

```
Failed setup, will retry: Failed to connect to Gecko device: 'refresh_token'
```

## Solution

Add `offline_access` to the OAuth scope in `oauth_implementation.py`:

```python
"scope": "openid profile email offline_access"
```

This ensures Auth0 returns both an `access_token` and a `refresh_token`, allowing Home Assistant to automatically renew credentials when they expire.

## Note for existing users

After this fix is merged, existing users will need to re-authenticate (remove and re-add the integration) to obtain a new token set that includes a refresh token.