### PR TITLE
fix: lowercase entity_id for HASS 2026.2

### DIFF
--- a/custom_components/gecko/fan.py
+++ b/custom_components/gecko/fan.py
@@ -39,7 +39,7 @@ async def async_setup_entry(
             pump_zones = vessel_coordinator.get_zones_by_type(ZoneType.FLOW_ZONE)
             flow_zones = [zone for zone in pump_zones if isinstance(zone, FlowZone)]
             for zone in flow_zones:
-                entity_id = f"{vessel_coordinator.vessel_name}_pump_{zone.id}"
+                entity_id = f"{vessel_coordinator.vessel_name}_pump_{zone.id}".lower()
                 if entity_id not in created_entity_ids:
                     entity = GeckoFan(vessel_coordinator, config_entry, zone)
                     new_entities.append(entity)
@@ -68,7 +68,7 @@ class GeckoFan(GeckoEntityAvailabilityMixin, CoordinatorEntity, FanEntity):
         CoordinatorEntity.__init__(self, coordinator)
         self._coordinator: GeckoVesselCoordinator = coordinator
         self._zone = zone
-        self.entity_id = f"fan.{coordinator.vessel_name}_pump_{zone.id}"
+        self.entity_id = f"fan.{coordinator.vessel_name}_pump_{zone.id}".lower()
         self._attr_name = f"{coordinator.vessel_name} {zone.name}"
         self._attr_unique_id = f"{config_entry.entry_id}_{coordinator.vessel_name}_pump_{zone.id}"
 

--- a/custom_components/gecko/light.py
+++ b/custom_components/gecko/light.py
@@ -51,7 +51,7 @@ async def async_setup_entry(
             
             for zone in light_zones:
                 # Check if entity already exists
-                entity_id = f"{coordinator.vessel_name}_light_{zone.id}"
+                entity_id = f"{coordinator.vessel_name}_light_{zone.id}".lower()
                 if entity_id not in created_entity_ids:
                     entity = GeckoLight(coordinator, config_entry, zone)
                     new_entities.append(entity)
@@ -86,7 +86,7 @@ class GeckoLight(GeckoEntityAvailabilityMixin, CoordinatorEntity, LightEntity):
         super().__init__(coordinator)
         
         self._zone = zone
-        self.entity_id = f"light.{coordinator.vessel_name}_light_{zone.id}"
+        self.entity_id = f"light.{coordinator.vessel_name}_light_{zone.id}".lower()
         
         self._attr_name = f"{coordinator.vessel_name} light zone {zone.id}"
         self._attr_unique_id = f"{config_entry.entry_id}_{coordinator.vessel_name}_light_{zone.id}"


### PR DESCRIPTION
With the update to Homeassistant to 2026.2.0 fan and light entities were unable to be created with the following error message:
`homeassistant.exceptions.HomeAssistantError: Invalid entity ID: fan.Pool_pump_1`

Also, this is not the only project affected by these changes: https://github.com/tomer-w/ha-victron-mqtt/pull/290/changes.

This is a quick fix for this integration. However, the climate entity was not affected by this API change. Should the `entity_id` really be coded, or rather the unique ID be used (https://developers.home-assistant.io/docs/entity_registry_index#unique-id-requirements)?