### PR TITLE
fix: Preserve refresh_token on token refresh, add reauth flow, bump version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,10 @@
 ---
 name: Bug Report
 about: Create a report to help us improve
-title: '[BUG] '
+title: "[BUG] "
 labels: bug
 assignees: ''
+
 ---
 
 ## Describe the Bug
@@ -25,7 +26,7 @@ If applicable, add screenshots to help explain your problem.
 ## Environment
 - Home Assistant Version: [e.g. 2025.12.0]
 - Gecko Integration Version: [e.g. 1.0.0]
-- Spa Model: [e.g. in.touch2]
+- Spa Model: [e.g. in.touch 3 / in.touch 3+]
 
 ## Logs
 ```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,9 +1,10 @@
 ---
 name: Feature Request
 about: Suggest an idea for this integration
-title: '[FEATURE] '
+title: "[FEATURE] "
 labels: enhancement
 assignees: ''
+
 ---
 
 ## Is your feature request related to a problem?

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ The integration creates multiple entity types for comprehensive spa control:
 **No devices discovered:**
 - Confirm your spa is online in the Gecko mobile app
 - Wait 1-2 minutes for discovery to complete
-- Check that your spa uses Gecko in.touch2 or compatible system
+- Check that your spa uses Gecko in.touch 3 / in.touch 3+ or compatible system
 
 **Entities not updating:**
 - Check RF signal strength sensor (low signal affects updates)

--- a/custom_components/gecko/__init__.py
+++ b/custom_components/gecko/__init__.py
@@ -130,6 +130,7 @@ def _setup_vessel_device(entry: ConfigEntry, vessel: dict, device_registry: dr.D
     vessel_name = vessel.get("name", f"Vessel {vessel_id}")
     vessel_type = vessel.get("type", "Unknown")
     protocol_name = vessel.get("protocolName", "Unknown")
+    monitor_id = vessel.get("monitorId")
     
     # Create a more descriptive device name
     device_name = vessel_name
@@ -142,6 +143,7 @@ def _setup_vessel_device(entry: ConfigEntry, vessel: dict, device_registry: dr.D
         manufacturer="Gecko",
         model=f"{vessel_type} ({protocol_name})",
         sw_version=None,
+        serial_number=monitor_id,
     )
 
 

--- a/custom_components/gecko/__init__.py
+++ b/custom_components/gecko/__init__.py
@@ -52,29 +52,22 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Gecko from a config entry."""
-    _LOGGER.info("Setting up Gecko integration with entry: %s", entry.entry_id)
-    
     implementation = (
         await config_entry_oauth2_flow.async_get_config_entry_implementation(
             hass, entry
         )
     )
-    _LOGGER.debug("OAuth2 implementation obtained: %s", implementation.domain)
 
     session = config_entry_oauth2_flow.OAuth2Session(hass, entry, implementation)
-    _LOGGER.debug("OAuth2 session created")
 
     # Create OAuth-based Gecko API client
     api_client = OAuthGeckoApi(hass, session)
-    _LOGGER.debug("API client created")
 
     # Create one coordinator per vessel following Home Assistant best practices
     vessels = entry.data.get("vessels", [])
     vessels_count = len(vessels)
-    _LOGGER.info("Creating %d vessel coordinators", vessels_count)
-    _LOGGER.debug("Config entry data keys: %s", list(entry.data.keys()))
     if vessels_count == 0:
-        _LOGGER.warning("No vessels in entry.data! Entry data: %s", {k: v for k, v in entry.data.items() if k != 'token'})
+        _LOGGER.warning("No vessels found in config entry")
     
     coordinators = []
     for vessel in vessels:
@@ -90,40 +83,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             vessel_name=vessel_name,
         )
         coordinators.append(coordinator)
-        _LOGGER.debug("Created coordinator for vessel %s (ID: %s, Monitor: %s)", vessel_name, vessel_id, monitor_id)
     
     # Store in runtime data
     entry.runtime_data = GeckoRuntimeData(
         api_client=api_client,
         coordinators=coordinators,
     )
-    _LOGGER.info("Created %d vessel coordinators", len(coordinators))
 
     # Create devices for each vessel/spa and set up geckoIotClient
-    _LOGGER.info("Setting up %d vessels and geckoIotClient connections", vessels_count)
     await _setup_vessels_and_gecko_clients(hass, entry)
-    _LOGGER.info("Vessels and geckoIotClient setup completed")
 
-    # Wait for initial zone data with a shorter timeout and proceed anyway if timeout
-    _LOGGER.info("Waiting for initial zone data to be loaded for all monitors...")
     # Set up platforms immediately - entities will be created when zone data becomes available
-    _LOGGER.info("Setting up platforms immediately")
-    _LOGGER.debug("Forwarding setup to platforms: %s", _PLATFORMS)
     await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
-    _LOGGER.info("Platforms set up successfully")
     
-    _LOGGER.info("Gecko integration setup completed successfully")
+    _LOGGER.info("Gecko integration setup completed for %d vessels", vessels_count)
 
     return True
 
 
 async def _setup_vessels_and_gecko_clients(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Set up devices for each vessel/spa and geckoIotClient connections."""
-    _LOGGER.debug("_setup_vessels_and_gecko_clients called")
-    
     runtime_data: GeckoRuntimeData = entry.runtime_data
     vessels = entry.data.get("vessels", [])
-    _LOGGER.info("Found %d vessels in config entry data", len(vessels))
     
     if not vessels:
         _LOGGER.warning("No vessels found in config entry data!")
@@ -132,23 +113,13 @@ async def _setup_vessels_and_gecko_clients(hass: HomeAssistant, entry: ConfigEnt
     device_registry = dr.async_get(hass)
     api_client = runtime_data.api_client
     
-    _LOGGER.debug("Setting up devices and geckoIotClient for %d vessels", len(vessels))
-    
     # Match each vessel with its coordinator
     for i, (vessel, coordinator) in enumerate(zip(vessels, runtime_data.coordinators)):
         vessel_name = vessel.get("name", f"Vessel {i}")
-        vessel_id = vessel.get("vesselId")
-        monitor_id = vessel.get("monitorId")
-        
-        _LOGGER.info("Processing vessel %d: name=%s, vesselId=%s, monitorId=%s", 
-                    i, vessel_name, vessel_id, monitor_id)
         
         try:
             _setup_vessel_device(entry, vessel, device_registry)
-            _LOGGER.debug("Device setup completed for vessel %s", vessel_name)
-            
             await _setup_vessel_gecko_client(vessel, api_client, coordinator)
-            _LOGGER.debug("GeckoIotClient setup completed for vessel %s", vessel_name)
         except Exception as e:
             _LOGGER.error("Failed to setup vessel %s: %s", vessel_name, e, exc_info=True)
 
@@ -159,19 +130,6 @@ def _setup_vessel_device(entry: ConfigEntry, vessel: dict, device_registry: dr.D
     vessel_name = vessel.get("name", f"Vessel {vessel_id}")
     vessel_type = vessel.get("type", "Unknown")
     protocol_name = vessel.get("protocolName", "Unknown")
-    
-    # Log spa configuration info for debugging
-    spa_config = vessel.get("spa_configuration", {})
-    if spa_config:
-        zones = spa_config.get("zones", {})
-        metadata = spa_config.get("metadata", {})
-        _LOGGER.info("Spa %s configuration: metadata=%s, zones=%s", vessel_name, metadata, list(zones.keys()))
-        
-        # Log details about available zones
-        for zone_type, zone_data in zones.items():
-            _LOGGER.debug("Spa %s - Zone type '%s': %s", vessel_name, zone_type, zone_data)
-    else:
-        _LOGGER.warning("No spa configuration found for vessel %s", vessel_name)
     
     # Create a more descriptive device name
     device_name = vessel_name
@@ -193,22 +151,17 @@ async def _setup_vessel_gecko_client(vessel: dict, api_client: OAuthGeckoApi, co
     vessel_name = vessel.get("name", f"Vessel {vessel_id}")
     monitor_id = vessel.get("monitorId")
     
-    _LOGGER.info("_setup_vessel_gecko_client called for vessel %s (ID: %s, Monitor: %s)", vessel_name, vessel_id, monitor_id)
-    
     if not monitor_id:
         _LOGGER.error("No monitor ID found for vessel %s. Available keys: %s", vessel_name, list(vessel.keys()))
         return
     
     try:
-        _LOGGER.info("Requesting livestream URL for monitor %s", monitor_id)
         livestream_data = await api_client.async_get_monitor_livestream(monitor_id)
         websocket_url = livestream_data.get("brokerUrl")
         
         if not websocket_url:
             _LOGGER.error("No WebSocket URL found in livestream response for monitor %s", monitor_id)
             return
-            
-        _LOGGER.info("Got WebSocket URL for monitor %s: %s", monitor_id, websocket_url[:50] + "...")
         
         # Don't create zones from spa configuration in coordinator - let GeckoIotClient handle this
         # The coordinator will get zones from the GeckoIotClient once it's connected and configured
@@ -218,9 +171,7 @@ async def _setup_vessel_gecko_client(vessel: dict, api_client: OAuthGeckoApi, co
             websocket_url=websocket_url
         )
         
-        if success:
-            _LOGGER.info("✅ Successfully setup connection for monitor %s", monitor_id)
-        else:
+        if not success:
             raise ConnectionError(f"Failed to setup connection for monitor {monitor_id}")
             
     except Exception as ex:
@@ -230,13 +181,10 @@ async def _setup_vessel_gecko_client(vessel: dict, api_client: OAuthGeckoApi, co
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    _LOGGER.info("Unloading Gecko integration entry: %s", entry.entry_id)
-    
     # Clean up all vessel coordinators
     runtime_data: GeckoRuntimeData = entry.runtime_data
     for coordinator in runtime_data.coordinators:
         await coordinator.async_shutdown()
-    _LOGGER.info("Shutdown %d vessel coordinators", len(runtime_data.coordinators))
     
     # Disconnect all monitors from the connection manager
     # This ensures fresh connections on reload with updated config/tokens
@@ -246,9 +194,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         for vessel in vessels:
             monitor_id = vessel.get("monitorId")
             if monitor_id:
-                _LOGGER.info("Disconnecting monitor %s during unload", monitor_id)
                 await connection_manager.async_disconnect_monitor(monitor_id)
     except Exception as ex:
-        _LOGGER.warning("Error disconnecting monitors during unload: %s", ex)
+        _LOGGER.error("Error disconnecting monitors during unload: %s", ex)
     
     return await hass.config_entries.async_unload_platforms(entry, _PLATFORMS)

--- a/custom_components/gecko/__init__.py
+++ b/custom_components/gecko/__init__.py
@@ -9,7 +9,7 @@ import os
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client, config_entry_oauth2_flow, config_validation as cv, device_registry as dr
 
 
@@ -101,7 +101,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady(f"Failed to connect to Gecko device: {ex}") from ex
     except KeyError as ex:
         # Missing required data (e.g., 'refresh_token') indicates auth issues
-        raise ConfigEntryNotReady(f"Failed to connect to Gecko device: {ex}") from ex
+        # that won't resolve on retry — trigger reauth instead
+        raise ConfigEntryAuthFailed(
+            f"Authentication data incomplete ({ex}). Please re-authenticate."
+        ) from ex
 
     # Set up platforms immediately - entities will be created when zone data becomes available
     await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)

--- a/custom_components/gecko/binary_sensor.py
+++ b/custom_components/gecko/binary_sensor.py
@@ -57,8 +57,6 @@ async def async_setup_entry(
 ) -> None:
     """Set up Gecko binary sensor entities from a config entry."""
     
-    _LOGGER.info("Setting up Gecko binary sensor entities")
-    
     # Get the vessel coordinators from runtime_data
     if not hasattr(config_entry, 'runtime_data') or not config_entry.runtime_data:
         _LOGGER.error("No runtime_data found for config entry")
@@ -72,8 +70,6 @@ async def async_setup_entry(
     # Create binary sensor entities for each vessel
     entities = []
     for coordinator in coordinators:
-        _LOGGER.debug("Creating binary sensors for vessel %s (%s)", coordinator.vessel_id, coordinator.vessel_name)
-        
         for description in BINARY_SENSOR_DESCRIPTIONS:
             entity = GeckoBinarySensorEntity(
                 coordinator=coordinator,
@@ -84,10 +80,10 @@ async def async_setup_entry(
             _LOGGER.debug("Created binary sensor entity %s for %s", description.key, coordinator.vessel_name)
     
     if entities:
-        _LOGGER.info("Adding %d binary sensor entities", len(entities))
+        _LOGGER.debug("Adding %d binary sensor entities", len(entities))
         async_add_entities(entities)
     else:
-        _LOGGER.warning("No binary sensor entities created")
+        _LOGGER.debug("No binary sensor entities created")
 
 
 class GeckoBinarySensorEntity(CoordinatorEntity[GeckoVesselCoordinator], BinarySensorEntity):

--- a/custom_components/gecko/climate.py
+++ b/custom_components/gecko/climate.py
@@ -43,7 +43,6 @@ async def async_setup_entry(
     def discover_new_climate_entities(coordinator: GeckoVesselCoordinator) -> None:
         """Discover climate entities for temperature control zones."""
         zones = coordinator.get_zones_by_type(ZoneType.TEMPERATURE_CONTROL_ZONE)
-        _LOGGER.debug("Discovered zones for vessel %s: %s", coordinator.vessel_name, zones)
         
         # Get or create the set of added zone IDs for this coordinator
         vessel_key = f"{coordinator.entry_id}_{coordinator.vessel_id}"
@@ -63,7 +62,7 @@ async def async_setup_entry(
         
         if entities:
             async_add_entities(entities)
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Added %d climate entities for vessel %s",
                 len(entities),
                 coordinator.vessel_name,
@@ -127,19 +126,17 @@ class GeckoClimate(GeckoEntityAvailabilityMixin, CoordinatorEntity[GeckoVesselCo
         self._attr_max_temp = self._zone.max_temperature_set_point_c
         self._attr_min_temp = self._zone.min_temperature_set_point_c
         
-        _LOGGER.info(
-            "Zone %s state: current_temp=%s, target_temp=%s, zone.set_point=%s, zone.target_temperature=%s",
+        _LOGGER.debug(
+            "Zone %s: current=%s°C, target=%s°C",
             self._zone.id,
             self._attr_current_temperature,
             self._attr_target_temperature,
-            getattr(self._zone, 'set_point', 'N/A'),
-            self._zone.target_temperature,
         )
     
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        _LOGGER.info("Updating climate entity %s from zone %s", self.entity_id, self._zone.id)
+        _LOGGER.debug("Updating climate entity %s", self.entity_id)
         self._update_from_zone()
         self.async_write_ha_state()
 
@@ -154,7 +151,7 @@ class GeckoClimate(GeckoEntityAvailabilityMixin, CoordinatorEntity[GeckoVesselCo
                 self._zone.set_target_temperature, temperature
             )
           
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Set target temperature to %.1f°C for %s",
                 temperature,
                 self.entity_id,

--- a/custom_components/gecko/climate.py
+++ b/custom_components/gecko/climate.py
@@ -14,6 +14,7 @@ from homeassistant.components.climate import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -162,3 +163,15 @@ class GeckoClimate(GeckoEntityAvailabilityMixin, CoordinatorEntity[GeckoVesselCo
             _LOGGER.error(
                 "Error setting temperature for %s: %s", self.entity_id, err
             )
+    
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set new target hvac mode."""
+        if hvac_mode != HVACMode.HEAT:
+            raise ServiceValidationError(
+                f"Unsupported HVAC mode: {hvac_mode}. Only HEAT mode is supported.",
+                translation_domain=DOMAIN,
+                translation_key="unsupported_hvac_mode",
+            )
+        
+        # HEAT mode is the only supported mode and is always active
+        _LOGGER.debug("HVAC mode set to HEAT for %s (no action required)", self.entity_id)

--- a/custom_components/gecko/config_flow.py
+++ b/custom_components/gecko/config_flow.py
@@ -56,12 +56,9 @@ class ConfigFlow(
             
             # Get user ID and account information
             user_id, account_data, account_id = await self._resolve_user_and_account(data, api_client)
-            _LOGGER.debug("Resolved user_id: %s, account_id: %s", user_id, account_id)
             
             # Get vessels for the account
-            _LOGGER.info("Fetching vessels for account %s from API...", account_id)
             vessels = await api_client.async_get_vessels(account_id)
-            _LOGGER.info("API returned %d vessels: %s", len(vessels) if vessels else 0, vessels)
             
             if not vessels:
                 self.logger.warning("No vessels found for account %s", account_id)
@@ -88,7 +85,6 @@ class ConfigFlow(
                             "spa_configuration": spa_config
                         }
                         vessels_with_config.append(vessel_with_config)
-                        _LOGGER.debug("Added spa config for vessel %s: %s", vessel.get("name"), spa_config)
                     else:
                         _LOGGER.warning("No monitor ID found for vessel %s", vessel.get("name"))
                         vessels_with_config.append(vessel)  # Add without config

--- a/custom_components/gecko/config_flow.py
+++ b/custom_components/gecko/config_flow.py
@@ -1,8 +1,10 @@
 """Config flow for Gecko."""
 
 import logging
+from collections.abc import Mapping
 from typing import Any
 
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.helpers import config_entry_oauth2_flow, aiohttp_client
 
 from .const import DOMAIN, OAUTH2_AUTHORIZE, OAUTH2_CLIENT_ID, OAUTH2_TOKEN
@@ -17,7 +19,10 @@ class ConfigFlow(
     """Config flow to handle Gecko OAuth2 authentication."""
 
     DOMAIN = DOMAIN
-    
+
+    # Reauth support: store the entry being re-authenticated
+    reauth_entry = None
+
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
         # Register the hardcoded OAuth implementation if not already registered
@@ -43,8 +48,50 @@ class ConfigFlow(
                 ),
             )
     
+    # ── Reauth flow ─────────────────────────────────────────────────────
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle re-authentication when the token can no longer be refreshed."""
+        self.reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm re-authentication with the user."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="reauth_confirm",
+                description_placeholders={
+                    "title": self.reauth_entry.title if self.reauth_entry else "Gecko"
+                },
+            )
+
+        # Register implementation and kick off the OAuth flow
+        await self.async_register_implementation()
+        return await super().async_step_user(user_input)
+
+    # ── Entry creation / update ─────────────────────────────────────────
+
     async def async_oauth_create_entry(self, data: dict):
-        """Create an entry after OAuth authentication."""
+        """Create an entry after OAuth authentication, or update an existing one on reauth."""
+
+        # ── Reauth path: update the existing entry with the new token ───
+        if self.reauth_entry is not None:
+            # Merge the new token into the existing config entry data so we
+            # preserve vessels, account info, etc. that were stored at first setup.
+            new_data = {**self.reauth_entry.data, "token": data["token"]}
+            self.hass.config_entries.async_update_entry(
+                self.reauth_entry, data=new_data
+            )
+            await self.hass.config_entries.async_reload(self.reauth_entry.entry_id)
+            return self.async_abort(reason="reauth_successful")
+
+        # ── Normal first-time setup path ────────────────────────────────
         # Get available vessels from the cloud API
         try:
             # Create a simple API client using just the access token for initial API calls

--- a/custom_components/gecko/connection_manager.py
+++ b/custom_components/gecko/connection_manager.py
@@ -42,6 +42,7 @@ class GeckoMonitorConnection:
     update_callbacks: list[Callable[[dict], None]] = field(default_factory=list)
     is_connected: bool = False
     connectivity_status: Any = None  # ConnectivityStatus from geckoIotClient
+    refresh_token_callback: Callable[[str | None], str] | None = None  # Store callback for reconnection
     
 
 class GeckoConnectionManager:
@@ -58,6 +59,42 @@ class GeckoConnectionManager:
         self._cleanup_listener = hass.bus.async_listen_once(
             EVENT_HOMEASSISTANT_STOP, self._async_shutdown
         )
+    
+    def _setup_client_handlers(
+        self,
+        gecko_client: Any,
+        connection: GeckoMonitorConnection,
+        monitor_id: str,
+    ) -> None:
+        """Set up zone update and connectivity handlers for a gecko client.
+        
+        This helper method extracts the common handler setup logic used when
+        creating or reconnecting monitor connections, following the DRY principle.
+        """
+        # Set up zone update handler to distribute to all callbacks
+        def on_zone_update(updated_zones):
+            # Copy callbacks list to avoid race conditions during iteration
+            callbacks = list(connection.update_callbacks)
+            for callback in callbacks:
+                try:
+                    callback(updated_zones)
+                except Exception as e:
+                    _LOGGER.error("Error in zone update callback for monitor %s: %s", monitor_id, e)
+        
+        # Set up connectivity update handler
+        def on_connectivity_update(connectivity_status):
+            # Store connectivity status in connection for easy access
+            connection.connectivity_status = connectivity_status
+            
+            # Update connection status based on connectivity
+            if hasattr(connectivity_status, 'vessel_status'):
+                # If vessel is running but transporter is not connected, we may need to refresh token
+                vessel_running = str(connectivity_status.vessel_status) == 'RUNNING'
+                if vessel_running and not connection.is_connected:
+                    _LOGGER.warning("Vessel running but connection not established for %s", monitor_id)
+        
+        gecko_client.on_zone_update(on_zone_update)
+        gecko_client.on(EventChannel.CONNECTIVITY_UPDATE, on_connectivity_update)
     
     async def async_get_or_create_connection(
         self,
@@ -91,40 +128,21 @@ class GeckoConnectionManager:
                                               transporter, 
                                               config_timeout=CONFIG_TIMEOUT)
                 
-                # Create connection object
+                # Create connection object with refresh callback for reconnection
                 connection = GeckoMonitorConnection(
                     monitor_id=monitor_id,
                     gecko_client=gecko_client,
                     websocket_url=websocket_url,
                     vessel_name=vessel_name,
+                    refresh_token_callback=refresh_token_callback,
                 )
                 
                 # Add callback if provided
                 if update_callback:
                     connection.update_callbacks.append(update_callback)
                 
-                # Set up zone update handler to distribute to all callbacks
-                def on_zone_update(updated_zones):
-                    for callback in connection.update_callbacks:
-                        try:
-                            callback(updated_zones)
-                        except Exception as e:
-                            _LOGGER.error("Error in zone update callback for monitor %s: %s", monitor_id, e)
-                
-                # Set up connectivity update handler
-                def on_connectivity_update(connectivity_status):
-                    # Store connectivity status in connection for easy access
-                    connection.connectivity_status = connectivity_status
-                    
-                    # Update connection status based on connectivity
-                    if hasattr(connectivity_status, 'vessel_status'):
-                        # If vessel is running but transporter is not connected, we may need to refresh token
-                        vessel_running = str(connectivity_status.vessel_status) == 'RUNNING'
-                        if vessel_running and not connection.is_connected:
-                            _LOGGER.warning("Vessel running but connection not established for %s", monitor_id)
-                
-                gecko_client.on_zone_update(on_zone_update)
-                gecko_client.on(EventChannel.CONNECTIVITY_UPDATE, on_connectivity_update)
+                # Set up handlers using the helper method
+                self._setup_client_handlers(gecko_client, connection, monitor_id)
                 
                 # Connect using executor since connect() is synchronous
                 await self.hass.async_add_executor_job(gecko_client.connect)
@@ -144,15 +162,19 @@ class GeckoConnectionManager:
         """Get existing connection for a monitor."""
         return self._connections.get(monitor_id)
     
-    def remove_callback(self, monitor_id: str, callback: Callable[[dict], None]) -> None:
-        """Remove a callback from a monitor connection."""
-        if monitor_id in self._connections:
-            connection = self._connections[monitor_id]
-            if callback in connection.update_callbacks:
-                connection.update_callbacks.remove(callback)
-                
-                # If no more callbacks, we could optionally disconnect
-                # For now, keep connections alive as they may be reused
+    async def async_remove_callback(self, monitor_id: str, callback: Callable[[dict], None]) -> None:
+        """Remove a callback from a monitor connection.
+        
+        Uses the connection lock to prevent race conditions with callback iteration.
+        """
+        async with self._connection_lock:
+            if monitor_id in self._connections:
+                connection = self._connections[monitor_id]
+                if callback in connection.update_callbacks:
+                    connection.update_callbacks.remove(callback)
+                    
+                    # If no more callbacks, we could optionally disconnect
+                    # For now, keep connections alive as they may be reused
     
     async def async_disconnect_monitor(self, monitor_id: str) -> None:
         """Disconnect and remove a monitor connection."""
@@ -170,6 +192,94 @@ class GeckoConnectionManager:
                 # Remove from connections
                 del self._connections[monitor_id]
     
+    async def async_reconnect_monitor(self, monitor_id: str) -> bool:
+        """Reconnect a specific monitor connection.
+        
+        This method disconnects the existing connection (if any) and establishes
+        a new connection using a fresh token from the refresh callback.
+        
+        Returns True if reconnection was successful, False otherwise.
+        """
+        if monitor_id not in self._connections:
+            _LOGGER.warning("No existing connection found for monitor %s to reconnect", monitor_id)
+            return False
+        
+        connection = self._connections[monitor_id]
+        
+        try:
+            # Get the token refresh callback from the existing connection
+            refresh_callback = None
+            if hasattr(connection.gecko_client, 'transporter') and hasattr(connection.gecko_client.transporter, '_token_refresh_callback'):
+                refresh_callback = connection.gecko_client.transporter._token_refresh_callback
+            
+            if not refresh_callback or not callable(refresh_callback):
+                _LOGGER.error("No token refresh callback available for monitor %s - cannot reconnect", monitor_id)
+                return False
+            
+            # Get fresh websocket URL with new token
+            _LOGGER.debug("Getting fresh token for monitor %s", monitor_id)
+            new_url = await self.hass.async_add_executor_job(refresh_callback, monitor_id)
+            
+            if not new_url or not isinstance(new_url, str):
+                _LOGGER.error("Failed to get new websocket URL for monitor %s", monitor_id)
+                return False
+            
+            # Disconnect existing connection
+            async with self._connection_lock:
+                if connection.is_connected and connection.gecko_client:
+                    try:
+                        await self.hass.async_add_executor_job(connection.gecko_client.disconnect)
+                    except Exception as e:
+                        _LOGGER.warning("Error disconnecting monitor %s during reconnect: %s", monitor_id, e)
+                    connection.is_connected = False
+                
+                # Brief delay before reconnecting
+                await asyncio.sleep(RECONNECT_DELAY)
+                
+                # Create new transporter and client with fresh URL
+                transporter = MqttTransporter(
+                    broker_url=new_url,
+                    monitor_id=monitor_id,
+                    token_refresh_callback=refresh_callback
+                )
+                
+                gecko_client = GeckoIotClient(monitor_id, transporter, config_timeout=CONFIG_TIMEOUT)
+                
+                # Set up zone update handler to distribute to all callbacks
+                def on_zone_update(updated_zones):
+                    for callback in connection.update_callbacks:
+                        try:
+                            callback(updated_zones)
+                        except Exception as e:
+                            _LOGGER.error("Error in zone update callback for monitor %s: %s", monitor_id, e)
+                
+                # Set up connectivity update handler
+                def on_connectivity_update(connectivity_status):
+                    connection.connectivity_status = connectivity_status
+                    if hasattr(connectivity_status, 'vessel_status'):
+                        vessel_running = str(connectivity_status.vessel_status) == 'RUNNING'
+                        if vessel_running and not connection.is_connected:
+                            _LOGGER.warning("Vessel running but connection not established for %s", monitor_id)
+                
+                gecko_client.on_zone_update(on_zone_update)
+                gecko_client.on(EventChannel.CONNECTIVITY_UPDATE, on_connectivity_update)
+                
+                # Update connection object with new client and URL
+                connection.gecko_client = gecko_client
+                connection.websocket_url = new_url
+                
+                # Connect with fresh token
+                await self.hass.async_add_executor_job(gecko_client.connect)
+                connection.is_connected = True
+                
+                _LOGGER.info("Successfully reconnected monitor %s", monitor_id)
+                return True
+                
+        except Exception as e:
+            _LOGGER.error("Failed to reconnect monitor %s: %s", monitor_id, e, exc_info=True)
+            connection.is_connected = False
+            return False
+    
     async def _async_shutdown(self, event: Event) -> None:
         """Shutdown all connections."""
         # Disconnect all monitors
@@ -185,39 +295,46 @@ class GeckoConnectionManager:
                 _LOGGER.error("Error in shutdown callback: %s", e)
     
     async def async_refresh_connection_token(self, monitor_id: str) -> bool:
-        """Refresh the token for a specific connection."""
-        if monitor_id not in self._connections:
-            _LOGGER.error("No connection found for monitor %s to refresh", monitor_id)
-            return False
+        """Refresh the token for a specific connection.
         
-        connection = self._connections[monitor_id]
-        
-        try:
-            # Disconnect current connection
-            if connection.gecko_client and connection.is_connected:
-                await self.hass.async_add_executor_job(connection.gecko_client.disconnect)
-                connection.is_connected = False
+        This method acquires the connection lock at entry to prevent race conditions
+        where the connection could be modified or removed by concurrent operations.
+        """
+        # Acquire lock at method entry to prevent race conditions
+        async with self._connection_lock:
+            if monitor_id not in self._connections:
+                _LOGGER.error("No connection found for monitor %s to refresh", monitor_id)
+                return False
             
-            # Wait briefly before getting new token
-            await asyncio.sleep(TOKEN_REFRESH_DELAY)
+            connection = self._connections[monitor_id]
+            
+            try:
+                # Disconnect current connection
+                if connection.gecko_client and connection.is_connected:
+                    await self.hass.async_add_executor_job(connection.gecko_client.disconnect)
+                    connection.is_connected = False
+                
+                # Wait briefly before getting new token
+                await asyncio.sleep(TOKEN_REFRESH_DELAY)
 
-            # Get fresh token via the refresh callback if available
-            new_url = None
-            refresh_callback = None
-            if hasattr(connection.gecko_client, 'transporter') and hasattr(connection.gecko_client.transporter, '_token_refresh_callback'):
-                refresh_callback = connection.gecko_client.transporter._token_refresh_callback
-            
-            if refresh_callback and callable(refresh_callback):
+                # Use the stored refresh callback from connection object (avoids accessing private attributes)
+                refresh_callback = connection.refresh_token_callback
+                
+                if not refresh_callback or not callable(refresh_callback):
+                    _LOGGER.warning("No token refresh callback available for monitor %s", monitor_id)
+                    return False
+
                 # Run the callback in executor since it might be blocking
                 new_url = await self.hass.async_add_executor_job(refresh_callback, monitor_id)
-                if new_url and isinstance(new_url, str) and new_url != connection.websocket_url:
+                
+                if not new_url or not isinstance(new_url, str):
+                    _LOGGER.error("Failed to get new websocket URL for monitor %s", monitor_id)
+                    return False
+                
+                if new_url != connection.websocket_url:
                     connection.websocket_url = new_url
-            else:
-                _LOGGER.warning("No token refresh callback available for monitor %s", monitor_id)
-                return False
 
-            # Re-instantiate transporter and gecko client with new token
-            if new_url:
+                # Re-instantiate transporter and gecko client with new token
                 transporter = MqttTransporter(
                     broker_url=new_url,
                     monitor_id=monitor_id,
@@ -227,42 +344,27 @@ class GeckoConnectionManager:
                 # Create new gecko client
                 gecko_client = GeckoIotClient(monitor_id, transporter, config_timeout=CONFIG_TIMEOUT)
                 
-                # Setup zone update handler to distribute to all callbacks
-                def on_zone_update(updated_zones):
-                    for callback in connection.update_callbacks:
-                        try:
-                            callback(updated_zones)
-                        except Exception as e:
-                            _LOGGER.error("Error in zone update callback for monitor %s: %s", monitor_id, e)
-                
-                # Set up connectivity update handler
-                def on_connectivity_update(connectivity_status):
-                    connection.connectivity_status = connectivity_status
-                    
-                    vessel_running = str(connectivity_status.vessel_status) == 'RUNNING'
-                    if vessel_running and not connection.is_connected:
-                        _LOGGER.warning("Vessel running but connection not established for %s", monitor_id)
-                
-                gecko_client.on_zone_update(on_zone_update)
-                gecko_client.on(EventChannel.CONNECTIVITY_UPDATE, on_connectivity_update)
+                # Set up handlers using the helper method (DRY principle)
+                self._setup_client_handlers(gecko_client, connection, monitor_id)
                 
                 # Update connection with new client
                 connection.gecko_client = gecko_client
 
-            # Wait briefly before reconnecting
-            await asyncio.sleep(RECONNECT_DELAY)
+                # Wait briefly before reconnecting
+                await asyncio.sleep(RECONNECT_DELAY)
 
-            # Reconnect with fresh token
-            await self.hass.async_add_executor_job(connection.gecko_client.connect)
-            connection.is_connected = True
+                # Reconnect with fresh token
+                await self.hass.async_add_executor_job(connection.gecko_client.connect)
+                connection.is_connected = True
 
-            _LOGGER.info("Refreshed and reconnected monitor %s", monitor_id)
-            return True
+                _LOGGER.info("Refreshed and reconnected monitor %s", monitor_id)
+                return True
 
-        except Exception as e:
-            _LOGGER.error("Failed to refresh token for monitor %s: %s", monitor_id, e, exc_info=True)
-            connection.is_connected = False
-            return False
+            except Exception as e:
+                _LOGGER.error("Failed to refresh token for monitor %s: %s", monitor_id, e, exc_info=True)
+                # State is already set to False within the lock if disconnect succeeded
+                # No need to set it again outside the lock (fixes race condition)
+                return False
     
     def add_shutdown_callback(self, callback: Callable[[], None]) -> None:
         """Add a callback to be called during shutdown."""

--- a/custom_components/gecko/const.py
+++ b/custom_components/gecko/const.py
@@ -9,3 +9,6 @@ AUTH0_URL_BASE = "https://gecko-prod.us.auth0.com"
 
 # API endpoints
 API_BASE_URL = "https://api.geckowatermonitor.com"
+
+# Client configuration
+CONFIG_TIMEOUT = 10.0  # Default timeout for GeckoIotClient configuration loading in seconds

--- a/custom_components/gecko/diagnostics.py
+++ b/custom_components/gecko/diagnostics.py
@@ -118,10 +118,14 @@ def _get_connection_diagnostics(connection_manager) -> dict[str, Any]:
             connectivity: ConnectivityStatus = connection.connectivity_status
             conn_data["connectivity_status"] = {
                 "transport_connected": connectivity.transport_connected,
-                "gateway_status": connectivity.gateway_status,
-                "vessel_status": connectivity.vessel_status,
+                "gateway_status": str(connectivity.gateway_status),
+                "vessel_status": str(connectivity.vessel_status),
                 "is_fully_connected": connectivity.is_fully_connected,
             }
+        
+        # Redact sensitive websocket URL
+        if conn_data.get("websocket_url"):
+            conn_data["websocket_url"] = "<REDACTED>"
         
         # Get gecko client info if available
         if connection.gecko_client:

--- a/custom_components/gecko/entity.py
+++ b/custom_components/gecko/entity.py
@@ -50,10 +50,8 @@ class GeckoEntityAvailabilityMixin:
 
         if register:
             gecko_client.on(EventChannel.CONNECTIVITY_UPDATE, self._on_connectivity_update)
-            _LOGGER.debug("Registered connectivity callback")
         else:
             gecko_client.off(EventChannel.CONNECTIVITY_UPDATE, self._on_connectivity_update)
-            _LOGGER.debug("Unregistered connectivity callback")
 
         self._connectivity_callback_registered = register
 
@@ -65,7 +63,7 @@ class GeckoEntityAvailabilityMixin:
         """
         new_availability = self._check_is_connected()
         if new_availability != self._attr_available:
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Availability changed: %s -> %s (gateway=%s, vessel=%s)",
                 self._attr_available,
                 new_availability,
@@ -81,27 +79,15 @@ class GeckoEntityAvailabilityMixin:
     def _update_availability(self) -> None:
         """Update availability from gecko_iot_client's is_connected property."""
         new_availability = self._check_is_connected()
-        _LOGGER.debug(
-            "Initial availability check: %s (was: %s)",
-            new_availability,
-            self._attr_available,
-        )
         self._attr_available = new_availability
 
     def _check_is_connected(self) -> bool:
         """Check if gecko_iot_client is connected."""
         gecko_client = self._get_gecko_client_sync()
         if not gecko_client:
-            _LOGGER.debug("No gecko client available, marking as unavailable")
             return False
         
-        is_connected = gecko_client.is_connected
-        _LOGGER.debug(
-            "Gecko client is_connected: %s (connectivity_status: %s)",
-            is_connected,
-            getattr(gecko_client, "_connectivity_status", "N/A"),
-        )
-        return is_connected
+        return gecko_client.is_connected
 
     def _get_gecko_client_sync(self) -> GeckoIotClient | None:
         """Get gecko client synchronously from connection manager."""

--- a/custom_components/gecko/fan.py
+++ b/custom_components/gecko/fan.py
@@ -39,7 +39,7 @@ async def async_setup_entry(
             pump_zones = vessel_coordinator.get_zones_by_type(ZoneType.FLOW_ZONE)
             flow_zones = [zone for zone in pump_zones if isinstance(zone, FlowZone)]
             for zone in flow_zones:
-                entity_id = f"{vessel_coordinator.vessel_name}_pump_{zone.id}"
+                entity_id = f"{vessel_coordinator.vessel_name}_pump_{zone.id}".lower()
                 if entity_id not in created_entity_ids:
                     entity = GeckoFan(vessel_coordinator, config_entry, zone)
                     new_entities.append(entity)
@@ -68,7 +68,7 @@ class GeckoFan(GeckoEntityAvailabilityMixin, CoordinatorEntity, FanEntity):
         CoordinatorEntity.__init__(self, coordinator)
         self._coordinator: GeckoVesselCoordinator = coordinator
         self._zone = zone
-        self.entity_id = f"fan.{coordinator.vessel_name}_pump_{zone.id}"
+        self.entity_id = f"fan.{coordinator.vessel_name}_pump_{zone.id}".lower()
         self._attr_name = f"{coordinator.vessel_name} {zone.name}"
         self._attr_unique_id = f"{config_entry.entry_id}_{coordinator.vessel_name}_pump_{zone.id}"
 

--- a/custom_components/gecko/fan.py
+++ b/custom_components/gecko/fan.py
@@ -129,15 +129,13 @@ class GeckoFan(GeckoEntityAvailabilityMixin, CoordinatorEntity, FanEntity):
     
     @callback
     def _handle_coordinator_update(self) -> None:
-        _LOGGER.info("Handling coordinator update for fan %s", self._attr_name)
+        _LOGGER.debug("Updating fan %s: is_on=%s, speed=%s", self._attr_name, self._attr_is_on, self._attr_speed)
         self._update_from_zone()
-        # Availability is now updated via CONNECTIVITY_UPDATE events, not polling
-        _LOGGER.info("Updated fan %s state: is_on=%s, speed=%s, available=%s", self._attr_name, self._attr_is_on, self._attr_speed, self._attr_available)
         self.async_write_ha_state()
         
     async def async_turn_on(self, percentage: int | None = None, preset_mode: str | None = None, **kwargs) -> None:
         """Turn the fan on. Optionally set speed by percentage."""
-        _LOGGER.info("Turning on pump %s", self._attr_name)
+        _LOGGER.debug("Turning on pump %s", self._attr_name)
         # Map percentage to speed
         speed = "low"
         if percentage is not None:
@@ -151,8 +149,6 @@ class GeckoFan(GeckoEntityAvailabilityMixin, CoordinatorEntity, FanEntity):
         
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the fan off."""
-        _LOGGER.info("Turning off pump %s", self._attr_name)
-    
         self._zone.deactivate()
         
     @property
@@ -161,7 +157,6 @@ class GeckoFan(GeckoEntityAvailabilityMixin, CoordinatorEntity, FanEntity):
         return self._attr_is_on 
         
     async def async_set_speed(self, speed: str) -> None:
-        _LOGGER.info("Setting pump %s speed to %s", self._attr_name, speed)
         # Map string speed to integer value expected by Gecko API
         speed_map = {
             "off": 0,
@@ -182,7 +177,6 @@ class GeckoFan(GeckoEntityAvailabilityMixin, CoordinatorEntity, FanEntity):
                 if set_speed_method and callable(set_speed_method):
                     set_speed_method(speed_value)
                     # Let the coordinator update handle state changes
-                    _LOGGER.info("✅ Successfully sent speed command for pump %s to %s", self._attr_name, speed)
                 else:
                     _LOGGER.warning("Zone %s does not have set_speed method", zone.id)
             else:

--- a/custom_components/gecko/light.py
+++ b/custom_components/gecko/light.py
@@ -51,7 +51,7 @@ async def async_setup_entry(
             
             for zone in light_zones:
                 # Check if entity already exists
-                entity_id = f"{coordinator.vessel_name}_light_{zone.id}"
+                entity_id = f"{coordinator.vessel_name}_light_{zone.id}".lower()
                 if entity_id not in created_entity_ids:
                     entity = GeckoLight(coordinator, config_entry, zone)
                     new_entities.append(entity)
@@ -86,7 +86,7 @@ class GeckoLight(GeckoEntityAvailabilityMixin, CoordinatorEntity, LightEntity):
         super().__init__(coordinator)
         
         self._zone = zone
-        self.entity_id = f"light.{coordinator.vessel_name}_light_{zone.id}"
+        self.entity_id = f"light.{coordinator.vessel_name}_light_{zone.id}".lower()
         
         self._attr_name = f"{coordinator.vessel_name} light zone {zone.id}"
         self._attr_unique_id = f"{config_entry.entry_id}_{coordinator.vessel_name}_light_{zone.id}"

--- a/custom_components/gecko/light.py
+++ b/custom_components/gecko/light.py
@@ -56,7 +56,6 @@ async def async_setup_entry(
                     entity = GeckoLight(coordinator, config_entry, zone)
                     new_entities.append(entity)
                     created_entity_ids.add(entity_id)
-                    _LOGGER.debug("Created light entity for vessel %s, zone %s", coordinator.vessel_name, zone.id)
             
             if new_entities:
                 async_add_entities(new_entities)
@@ -131,7 +130,6 @@ class GeckoLight(GeckoEntityAvailabilityMixin, CoordinatorEntity, LightEntity):
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the light on."""
-        _LOGGER.info("Turning on light %s", self._attr_name)
         try:
             # Check if gecko client is connected
             gecko_client = await self.coordinator.get_gecko_client()
@@ -146,8 +144,6 @@ class GeckoLight(GeckoEntityAvailabilityMixin, CoordinatorEntity, LightEntity):
                 activate_method = getattr(zone, "activate", None)
                 if activate_method and callable(activate_method):
                     activate_method()
-                    # Let the coordinator update handle state changes
-                    _LOGGER.info("✅ Successfully sent turn on command for light %s", self._attr_name)
                 else:
                     _LOGGER.warning("Zone %s does not have activate method", zone.id)
             else:
@@ -157,7 +153,6 @@ class GeckoLight(GeckoEntityAvailabilityMixin, CoordinatorEntity, LightEntity):
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the light off."""
-        _LOGGER.info("Turning off light %s", self._attr_name)
         try:
             # Check if gecko client is connected
             gecko_client = await self.coordinator.get_gecko_client()
@@ -172,8 +167,6 @@ class GeckoLight(GeckoEntityAvailabilityMixin, CoordinatorEntity, LightEntity):
                 deactivate_method = getattr(zone, "deactivate", None)
                 if deactivate_method and callable(deactivate_method):
                     deactivate_method()
-                    # Let the coordinator update handle state changes
-                    _LOGGER.info("✅ Successfully sent turn off command for light %s", self._attr_name)
                 else:
                     _LOGGER.warning("Zone %s does not have deactivate method", zone.id)
             else:

--- a/custom_components/gecko/manifest.json
+++ b/custom_components/gecko/manifest.json
@@ -11,6 +11,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/geckoal/ha-gecko-integration/issues",
   "loggers": ["gecko_iot_client"],
-  "requirements": ["awsiotsdk==1.26.0", "gecko-iot-client==0.2.2"],
-  "version": "2.0.2"
+  "requirements": ["awsiotsdk==1.26.0", "gecko-iot-client==0.2.3"],
+  "version": "2.0.3"
 }

--- a/custom_components/gecko/manifest.json
+++ b/custom_components/gecko/manifest.json
@@ -12,5 +12,5 @@
   "issue_tracker": "https://github.com/geckoal/ha-gecko-integration/issues",
   "loggers": ["gecko_iot_client"],
   "requirements": ["awsiotsdk==1.26.0", "gecko-iot-client==0.2.3"],
-  "version": "2.0.3"
+  "version": "2.0.4"
 }

--- a/custom_components/gecko/manifest.json
+++ b/custom_components/gecko/manifest.json
@@ -11,6 +11,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/geckoal/ha-gecko-integration/issues",
   "loggers": ["gecko_iot_client"],
-  "requirements": ["awsiotsdk==1.26.0", "gecko-iot-client==0.2.4"],
-  "version": "2.0.5"
+  "requirements": ["awsiotsdk==1.26.0", "gecko-iot-client==0.2.5"],
+  "version": "2.0.6"
 }

--- a/custom_components/gecko/manifest.json
+++ b/custom_components/gecko/manifest.json
@@ -11,6 +11,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/geckoal/ha-gecko-integration/issues",
   "loggers": ["gecko_iot_client"],
-  "requirements": ["awsiotsdk==1.26.0", "gecko-iot-client==0.2.3"],
-  "version": "2.0.4"
+  "requirements": ["awsiotsdk==1.26.0", "gecko-iot-client==0.2.4"],
+  "version": "2.0.5"
 }

--- a/custom_components/gecko/manifest.json
+++ b/custom_components/gecko/manifest.json
@@ -12,5 +12,5 @@
   "issue_tracker": "https://github.com/geckoal/ha-gecko-integration/issues",
   "loggers": ["gecko_iot_client"],
   "requirements": ["awsiotsdk==1.26.0", "gecko-iot-client==0.2.5"],
-  "version": "2.0.6"
+  "version": "2.0.8"
 }

--- a/custom_components/gecko/oauth_implementation.py
+++ b/custom_components/gecko/oauth_implementation.py
@@ -19,7 +19,9 @@ class GeckoPKCEOAuth2Implementation(config_entry_oauth2_flow.LocalOAuth2Implemen
         """Extra data for the authorize URL."""
         data = super().extra_authorize_data  # This includes code_challenge and code_challenge_method
         data.update({
-            "scope": "openid profile email",
+            # offline_access is REQUIRED to receive a refresh_token from Auth0
+            # Without it, only an access_token is returned which expires and cannot be renewed
+            "scope": "openid profile email offline_access",
             "audience": "https://api.geckowatermonitor.com"
         })
         return data

--- a/custom_components/gecko/oauth_implementation.py
+++ b/custom_components/gecko/oauth_implementation.py
@@ -1,14 +1,18 @@
 """OAuth2 implementation for the Gecko integration.
 
 This module provides a PKCE-based OAuth2 implementation with a hardcoded
-public Client ID. PKCE (Proof Key for Code Exchange) uses cryptographic 
-code challenges instead of a static client secret, making it secure even 
+public Client ID. PKCE (Proof Key for Code Exchange) uses cryptographic
+code challenges instead of a static client secret, making it secure even
 with a public Client ID.
 
 No Application Credentials setup is required - the integration works out of the box!
 """
 
+import logging
+
 from homeassistant.helpers import config_entry_oauth2_flow
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class GeckoPKCEOAuth2Implementation(config_entry_oauth2_flow.LocalOAuth2ImplementationWithPkce):
@@ -25,3 +29,28 @@ class GeckoPKCEOAuth2Implementation(config_entry_oauth2_flow.LocalOAuth2Implemen
             "audience": "https://api.geckowatermonitor.com"
         })
         return data
+
+    async def async_refresh_token(self, token: dict) -> dict:
+        """Refresh tokens, preserving the refresh_token if the server omits it.
+
+        Auth0 (and some other OAuth2 providers) may not return a new
+        refresh_token in the refresh response when the existing one is still
+        valid. The HA core OAuth2 helpers replace the stored token wholesale
+        with the response, which drops the refresh_token key. On the next
+        refresh cycle the integration crashes with KeyError: 'refresh_token'.
+
+        This override ensures the original refresh_token is carried forward
+        when the server does not issue a replacement.
+        """
+        existing_refresh_token = token.get("refresh_token")
+
+        new_token = await super().async_refresh_token(token)
+
+        if "refresh_token" not in new_token and existing_refresh_token:
+            _LOGGER.debug(
+                "Auth0 refresh response did not include a new refresh_token; "
+                "carrying forward the existing one"
+            )
+            new_token["refresh_token"] = existing_refresh_token
+
+        return new_token

--- a/custom_components/gecko/select.py
+++ b/custom_components/gecko/select.py
@@ -36,7 +36,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Gecko select entities."""
-    _LOGGER.debug("Setting up Gecko select entities for entry: %s", entry.entry_id)
+    _LOGGER.debug("Setting up Gecko select entities")
     
     # Get runtime data with per-vessel coordinators
     runtime_data = entry.runtime_data
@@ -61,13 +61,11 @@ async def async_setup_entry(
         )
     
     if entities:
-        _LOGGER.info("Adding %d Gecko select entities", len(entities))
+        _LOGGER.debug("Adding %d Gecko select entities", len(entities))
         async_add_entities(entities)
-    else:
-        _LOGGER.warning("No select entities to add")
 
 
-class GeckoWatercareSelectEntity(GeckoEntityAvailabilityMixin, CoordinatorEntity[GeckoVesselCoordinator], SelectEntity):
+class GeckoWatercareSelectEntity(GeckoEntityAvailabilityMixin, CoordinatorEntity, SelectEntity):
     """Representation of a Gecko watercare mode select."""
 
     def __init__(
@@ -77,7 +75,8 @@ class GeckoWatercareSelectEntity(GeckoEntityAvailabilityMixin, CoordinatorEntity
         vessel_id: str,
     ) -> None:
         """Initialize the select."""
-        super().__init__(coordinator)
+        SelectEntity.__init__(self)
+        CoordinatorEntity.__init__(self, coordinator)
         
         self._vessel_name = vessel_name
         self._vessel_id = vessel_id
@@ -144,8 +143,8 @@ class GeckoWatercareSelectEntity(GeckoEntityAvailabilityMixin, CoordinatorEntity
         if option not in WATERCARE_MODE_OPTIONS:
             _LOGGER.error("Invalid watercare mode option: %s", option)
             return
-            
-        _LOGGER.info("Setting watercare mode for %s to %s", self._attr_name, option)
+        
+        _LOGGER.debug("Setting watercare mode for %s to %s", self._attr_name, option)
         
         try:
             # Get the gecko client for this vessel
@@ -159,13 +158,13 @@ class GeckoWatercareSelectEntity(GeckoEntityAvailabilityMixin, CoordinatorEntity
                 _LOGGER.error("Operation mode controller not available for vessel %s", self._vessel_name)
                 return
                 
-            _LOGGER.info("Setting operation mode to %s for vessel %s", option, self._vessel_name)
+            _LOGGER.debug("Setting operation mode to %s for vessel %s", option, self._vessel_name)
             
             # Use the clean API to set the mode by name
             gecko_client.operation_mode_controller.set_mode_by_name(option)
             
             # Let the coordinator update handle state changes
-            _LOGGER.info("✅ Successfully sent watercare mode command for %s", self._attr_name)
+            _LOGGER.debug("Sent watercare mode command for %s", self._attr_name)
             
             # Request coordinator refresh to get updated state from the device
             await self.coordinator.async_request_refresh()

--- a/custom_components/gecko/strings.json
+++ b/custom_components/gecko/strings.json
@@ -3,9 +3,14 @@
     "step": {
       "pick_implementation": {
         "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate Gecko",
+        "description": "The authentication for **{title}** has expired. Please sign in again to continue using your Gecko devices."
       }
     },
     "abort": {
+      "reauth_successful": "Re-authentication was successful.",
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",


### PR DESCRIPTION
## Summary

Fixes #28, Fixes #29

- **Preserve refresh_token during token refresh**: Auth0 omits `refresh_token` from refresh responses when the existing one is still valid. HA's OAuth2Session replaces the stored token wholesale, silently dropping the key. This override carries forward the existing `refresh_token` when Auth0's response omits it.
- **Trigger reauth instead of infinite retry**: Changed the `KeyError` handler from `ConfigEntryNotReady` to `ConfigEntryAuthFailed`, so HA prompts for re-authentication instead of retrying forever.
- **Add reauth flow**: Users can now re-authenticate without deleting and recreating the integration, preserving all vessel/account configuration.
- **Bump version**: `manifest.json` version from 2.0.6 to 2.0.8.

## Test plan

- [ ] Authenticate normally and wait for access token expiry (or manually set `expires_at` in the past). Verify the token refreshes without losing `refresh_token`.
- [ ] Manually remove `refresh_token` from the config entry storage file, restart HA, and verify the integration shows "Requires reconfiguration" rather than retrying forever.
- [ ] Complete the reauth flow via the UI and verify the integration recovers with all entities intact.
- [ ] Verify `manifest.json` shows version 2.0.8.