### PR TITLE
Upstream/python 3 14 awscrt crash

### DIFF
--- a/custom_components/gecko/aws_compat.py
+++ b/custom_components/gecko/aws_compat.py
@@ -1,0 +1,82 @@
+"""Runtime compatibility checks for the AWS Common Runtime.
+
+The AWS IoT SDK uses a native extension. Calling an incompatible build can
+terminate the entire Home Assistant process, so validate the loaded runtime
+before Gecko constructs an MQTT client.
+"""
+
+from __future__ import annotations
+
+import platform
+import re
+import sys
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any
+
+MINIMUM_AWSCRT_VERSION = (0, 36, 1)
+REQUIRED_AWSCRT_VERSION = "0.36.1"
+
+
+class AwsCrtCompatibilityError(OSError):
+    """Raised before entering an unsafe or inconsistent AWS CRT runtime."""
+
+
+def _version_tuple(value: str) -> tuple[int, int, int]:
+    """Return a comparable three-part tuple for a package version."""
+    match = re.match(r"^(\d+)\.(\d+)(?:\.(\d+))?", value)
+    if match is None:
+        return (0, 0, 0)
+    return tuple(int(part or 0) for part in match.groups())
+
+
+def runtime_compatibility_error(
+    *,
+    installed_version: str,
+    python_version: tuple[int, ...],
+    machine: str,
+    tls_context_type: type[Any],
+) -> str | None:
+    """Describe an unsafe AWS CRT runtime, or return ``None`` when usable."""
+    if _version_tuple(installed_version) < MINIMUM_AWSCRT_VERSION:
+        environment = f"Python {python_version[0]}.{python_version[1]} on {machine}"
+        return (
+            f"awscrt {installed_version} is unsafe for Gecko on {environment}; "
+            f"awscrt {REQUIRED_AWSCRT_VERSION} or newer is required. "
+            "Home Assistant was not allowed to start the native MQTT client."
+        )
+
+    # awscrt 0.36.x added this slot together with the IoT metrics path used by
+    # awsiotsdk 1.31.x. Its absence while package metadata reports a newer
+    # version means modules from different installations are resident in the
+    # same Python process. This can happen on the first dependency upgrade.
+    if not hasattr(tls_context_type, "_certificate_source"):
+        return (
+            "The loaded AWS CRT modules do not match the installed package. "
+            "Perform a full Home Assistant restart before reloading Gecko."
+        )
+
+    return None
+
+
+def ensure_aws_crt_compatible() -> None:
+    """Refuse to enter the native MQTT client with an incompatible CRT."""
+    try:
+        installed_version = version("awscrt")
+    except PackageNotFoundError as err:
+        raise AwsCrtCompatibilityError("The awscrt package is not installed") from err
+
+    try:
+        from awscrt.io import ClientTlsContext
+    except (ImportError, AttributeError) as err:
+        raise AwsCrtCompatibilityError(
+            "The AWS CRT Python modules could not be loaded consistently"
+        ) from err
+
+    problem = runtime_compatibility_error(
+        installed_version=installed_version,
+        python_version=sys.version_info[:3],
+        machine=platform.machine(),
+        tls_context_type=ClientTlsContext,
+    )
+    if problem is not None:
+        raise AwsCrtCompatibilityError(problem)

--- a/custom_components/gecko/connection_manager.py
+++ b/custom_components/gecko/connection_manager.py
@@ -17,6 +17,7 @@ from gecko_iot_client.models.events import EventChannel
 from gecko_iot_client import GeckoIotClient
 from gecko_iot_client.transporters.mqtt import MqttTransporter
 
+from .aws_compat import ensure_aws_crt_compatible
 from .const import DOMAIN, CONFIG_TIMEOUT
 
 _LOGGER = logging.getLogger(__name__)
@@ -118,6 +119,11 @@ class GeckoConnectionManager:
             # Create new connection
             
             try:
+                # awscrt is a native extension. Validate the loaded package
+                # before entering MQTT client construction so an old Python
+                # 3.14/aarch64 wheel cannot terminate Home Assistant.
+                ensure_aws_crt_compatible()
+
                 # Create transporter and client 
                 transporter = MqttTransporter(
                     broker_url=websocket_url, 
@@ -234,6 +240,8 @@ class GeckoConnectionManager:
                 
                 # Brief delay before reconnecting
                 await asyncio.sleep(RECONNECT_DELAY)
+
+                ensure_aws_crt_compatible()
                 
                 # Create new transporter and client with fresh URL
                 transporter = MqttTransporter(
@@ -316,6 +324,8 @@ class GeckoConnectionManager:
                 
                 if new_url != connection.websocket_url:
                     connection.websocket_url = new_url
+
+                ensure_aws_crt_compatible()
 
                 # Re-instantiate transporter and gecko client with new token
                 transporter = MqttTransporter(

--- a/custom_components/gecko/manifest.json
+++ b/custom_components/gecko/manifest.json
@@ -11,6 +11,10 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/geckoal/ha-gecko-integration/issues",
   "loggers": ["gecko_iot_client"],
-  "requirements": ["awsiotsdk==1.29.0", "gecko-iot-client==1.0.3"],
-  "version": "2.1.0"
+  "requirements": [
+    "awscrt==0.36.1",
+    "awsiotsdk==1.31.0",
+    "gecko-iot-client==1.0.3"
+  ],
+  "version": "2.1.1"
 }

--- a/tests/test_aws_compat.py
+++ b/tests/test_aws_compat.py
@@ -1,0 +1,83 @@
+"""Regression tests for the native AWS CRT startup guard."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+
+
+def _load_aws_compat_module():
+    """Load the dependency-free compatibility helpers."""
+    path = ROOT / "custom_components" / "gecko" / "aws_compat.py"
+    spec = importlib.util.spec_from_file_location("gecko_aws_compat_test", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+aws_compat = _load_aws_compat_module()
+
+
+class _LegacyTlsContext:
+    """Represent the class shape loaded from awscrt 0.32.x."""
+
+
+class _CurrentTlsContext:
+    """Represent the class shape loaded from awscrt 0.36.x."""
+
+    __slots__ = ("_certificate_source",)
+
+
+class AwsCompatibilityTests(unittest.TestCase):
+    """Verify unsafe native runtimes are rejected before MQTT construction."""
+
+    def test_python_314_arm64_rejects_crashing_legacy_runtime(self) -> None:
+        problem = aws_compat.runtime_compatibility_error(
+            installed_version="0.32.1",
+            python_version=(3, 14, 0),
+            machine="aarch64",
+            tls_context_type=_LegacyTlsContext,
+        )
+
+        self.assertIn("unsafe", problem)
+        self.assertIn("0.36.1", problem)
+
+    def test_current_matched_runtime_is_accepted(self) -> None:
+        problem = aws_compat.runtime_compatibility_error(
+            installed_version="0.36.1",
+            python_version=(3, 14, 0),
+            machine="aarch64",
+            tls_context_type=_CurrentTlsContext,
+        )
+
+        self.assertIsNone(problem)
+
+    def test_partially_upgraded_runtime_requires_full_restart(self) -> None:
+        problem = aws_compat.runtime_compatibility_error(
+            installed_version="0.36.1",
+            python_version=(3, 14, 0),
+            machine="aarch64",
+            tls_context_type=_LegacyTlsContext,
+        )
+
+        self.assertIn("full Home Assistant restart", problem)
+
+    def test_manifest_pins_a_matched_aws_runtime(self) -> None:
+        manifest = json.loads(
+            (ROOT / "custom_components" / "gecko" / "manifest.json").read_text(
+                encoding="utf-8"
+            )
+        )
+
+        self.assertEqual(manifest["version"], "2.1.1")
+        self.assertIn("awscrt==0.36.1", manifest["requirements"])
+        self.assertIn("awsiotsdk==1.31.0", manifest["requirements"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes the Home Assistant Core startup crash reported in #52 on Python 3.14 / aarch64 when the integration initializes the AWS IoT MQTT client.

The crash occurs inside the native `_awscrt` extension during MQTT client construction, which can terminate the entire Home Assistant Core process rather than failing the integration cleanly.

## Changes

* Add an AWS CRT compatibility shim for the affected Python 3.14 startup path
* Apply the compatibility handling before the Gecko MQTT connection is initialized
* Update the integration dependency metadata as needed for the compatible AWS stack
* Add tests covering the compatibility behavior

## Testing

This branch has been installed and tested on a real Home Assistant installation that was previously affected by the startup issue.

Home Assistant now starts successfully with the Gecko integration enabled, and the spa connection initializes normally.

Fixes #52
